### PR TITLE
Add License and License file in the setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [aliases]
 test=pytest
+
+[metadata]
+license = Apache-2.0
+license_files = LICENCE


### PR DESCRIPTION
Actually the License is not exported in the package.

https://files.pythonhosted.org/packages/77/da/a2448ccfe19d58c49a8bceda47dc960d8622f5dfa86ecf3b730ffa67b0e3/swagger_ui_bundle-0.0.9.tar.gz
